### PR TITLE
fix(loader): accept 'source' as fallback for Iframe src attribute

### DIFF
--- a/src/textbook-loader/transformer.ts
+++ b/src/textbook-loader/transformer.ts
@@ -338,7 +338,7 @@ export class Transformer {
 
   private convertIframe(attrs: Record<string, Cell>): Node {
     return this.createNode("Iframe", {
-      src: this.getTrimmedString(attrs.src),
+      src: this.getTrimmedString(attrs.src ?? attrs.source),
       stillImage: this.getImage(attrs["still_image"]),
       caption: this.getSpanGroup(attrs["caption"])
     })


### PR DESCRIPTION
## Summary
- Iframe component tables in the Risks, Governance, and Evaluations chapter docs use a `source` row name instead of `src`. `convertIframe` only reads `attrs.src`, so ~15 interactive figures across 9 sections render with an empty iframe URL and an infinite loading spinner.
- One-line change: read `attrs.src ?? attrs.source` so the transformer tolerates both conventions.

Closes #5.

## Tested:
- [x] Ran `pnpm dev` locally and verified previously broken figures now render correctly, including the two on `/chapters/v1/evaluations/benchmarks/`.
- [x] Verified Chapter 1 figures (which use `src`) still render correctly — no regression.