### PR TITLE
fix(test): run the verify chain on Windows

### DIFF
--- a/tests/a11y/a11y.test.ts
+++ b/tests/a11y/a11y.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { spawn, type ChildProcess } from 'child_process';
+
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 import { chromium, type Browser, type Page } from 'playwright';
 import AxeBuilder from '@axe-core/playwright';
+
+// On Windows pnpm is a .cmd shim: spawn will not resolve it through
+// PATHEXT, and recent Node refuses to launch .cmd files without a shell.
+// The arguments here are literals, so enabling the shell is safe.
+const PNPM = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+const PNPM_SHELL = process.platform === 'win32';
 
 // Boots `astro preview` against the existing dist/ and runs axe-core against
 // a fixed set of representative pages. Baseline-aware: existing violations
@@ -106,9 +113,9 @@ describe('axe-core accessibility scan', () => {
     }
 
     server = spawn(
-      'pnpm',
+      PNPM,
       ['exec', 'astro', 'preview', '--port', String(PREVIEW_PORT), '--host', PREVIEW_HOST],
-      { stdio: ['ignore', 'pipe', 'pipe'], env: process.env },
+      { stdio: ['ignore', 'pipe', 'pipe'], env: process.env, shell: PNPM_SHELL },
     );
 
     await waitForServer(BASE_URL + '/', 30_000);

--- a/tests/smoke/contributor-build.smoke.test.ts
+++ b/tests/smoke/contributor-build.smoke.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'child_process';
 import { readFileSync, readdirSync, statSync } from 'fs';
-import { join } from 'path';
+import { join, sep } from 'path';
+
+// On Windows pnpm is a .cmd shim: execFileSync will not resolve it through
+// PATHEXT, and recent Node refuses to launch .cmd files without a shell.
+// The arguments here are literals, so enabling the shell is safe.
+const PNPM = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+const PNPM_SHELL = process.platform === 'win32';
 
 /**
  * End-to-end smoke test for the contributor build path.
@@ -24,7 +30,9 @@ describe('contributor build smoke test', () => {
   it('a built chapter section page contains an <h1>, prose, and navigation links', () => {
     const dist = join(process.cwd(), 'dist');
     const candidates = walkChapterIndexPages(join(dist, 'chapters'));
-    const versioned = candidates.filter((p) => /\/chapters\/v\d+\//.test(p));
+    const versioned = candidates.filter((p) =>
+      /\/chapters\/v\d+\//.test(p.split(sep).join('/')),
+    );
     expect(versioned.length).toBeGreaterThan(0);
 
     // Pick the largest versioned section page — that's the one most
@@ -45,7 +53,8 @@ describe('contributor build smoke test', () => {
   }, 60_000);
 
   it('pnpm build succeeds without .env and produces chapter HTML', () => {
-    execFileSync('pnpm', ['build'], {
+    execFileSync(PNPM, ['build'], {
+      shell: PNPM_SHELL,
       cwd: process.cwd(),
       env: {
         ...process.env,


### PR DESCRIPTION
`pnpm verify` -- and with it the pre-push hook -- fails on Windows on any branch, before it gets to whatever is being pushed. Two test-only causes:

- **pnpm is a `.cmd` shim on Windows.** `execFileSync` / `spawn` do not resolve it through `PATHEXT` the way a shell does, and recent Node refuses to launch a `.cmd` without a shell. The smoke and a11y suites now use `pnpm.cmd` and enable `shell` only on `win32`; the arguments at both call sites are literals.
- **The smoke test matched built chapter pages with a forward-slash regex** applied to paths from `path.join`, which are backslash-separated on Windows. It matched nothing, so the suite reported that no versioned pages had been built when all 79 were present. Paths are normalised before matching.

Both changes are identities off Windows: `process.platform === 'win32'` is false, so the command string and `shell: false` are exactly what they were, and `p.split('/').join('/')` leaves a POSIX path untouched. Nothing under `src/` is touched.

Verified on Windows 11 (Node 26.7, pnpm 10.34): the whole chain passes -- lint, lint:actions, astro check, 126 unit tests, build (383 pages), smoke, a11y.

Sent on its own, separately from the read-along work, so it can be reviewed by itself.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
